### PR TITLE
Generate avro from schema

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -34,6 +34,7 @@ library
                         Data.Avro.EncodeRaw,
                         Data.Avro.Schema,
                         Data.Avro.Types,
+                        Data.Avro.TH,
                         Data.Avro.Zag,
                         Data.Avro.Zig
   -- other-modules:
@@ -56,7 +57,8 @@ library
                        vector,
                        pure-zlib,
                        semigroups,
-                       tagged
+                       tagged,
+                       template-haskell
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -O2
@@ -102,5 +104,6 @@ test-suite test
                       , pure-zlib
                       , semigroups
                       , tagged
+                      , template-haskell
                       , hspec
                       , QuickCheck

--- a/avro.cabal
+++ b/avro.cabal
@@ -78,6 +78,7 @@ test-suite test
                       , Avro.Codec.TextSpec
                       , Avro.Codec.ZigZagSpec
                       , Avro.EncodeRawSpec
+                      , Avro.THSpec
                       , Avro.ToAvroSpec
 
   main-is:              Spec.hs

--- a/avro.cabal
+++ b/avro.cabal
@@ -13,7 +13,7 @@ maintainer:          tommd@galois.com
 -- copyright:
 category:            Data
 build-type:          Simple
-extra-source-files:  ChangeLog.md
+extra-source-files:  ChangeLog.md, test/data/reused.avsc, test/data/small.avsc
 cabal-version:       >=1.10
 
 source-repository head
@@ -78,7 +78,8 @@ test-suite test
                       , Avro.Codec.TextSpec
                       , Avro.Codec.ZigZagSpec
                       , Avro.EncodeRawSpec
-                      , Avro.THSpec
+                      , Avro.SchemaSpec
+                      , Avro.THSimpleSpec
                       , Avro.ToAvroSpec
 
   main-is:              Spec.hs

--- a/avro.cabal
+++ b/avro.cabal
@@ -79,6 +79,7 @@ test-suite test
                       , Avro.Codec.ZigZagSpec
                       , Avro.EncodeRawSpec
                       , Avro.SchemaSpec
+                      , Avro.THReusedSpec
                       , Avro.THSimpleSpec
                       , Avro.ToAvroSpec
 

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -22,11 +22,13 @@ module Data.Avro.Schema
   , typeName
   , buildTypeEnvironment
   , Result(..)
+  , extractRecords
   ) where
 
 import           Prelude as P
 import           Control.Applicative
 import           Control.Monad.Except
+import           Control.Monad.State.Strict
 import qualified Control.Monad.Fail as MF
 import qualified Data.Aeson as A
 import           Data.Aeson ((.=),object,(.:?),(.:),(.!=),FromJSON(..),ToJSON(..))
@@ -34,10 +36,12 @@ import           Data.Aeson.Types (Parser,typeMismatch)
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.HashMap.Strict as HashMap
 import           Data.Hashable
+import qualified Data.List as L
 import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
-import           Data.Maybe (catMaybes)
+import           Data.Maybe (catMaybes, fromMaybe)
 import           Data.Monoid ((<>), First(..))
+import qualified Data.Set as S
 import           Data.String
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -414,7 +418,7 @@ parseAvroJSON env ty av =
             maybe (fail $ "No match for given record in union '" <> show (typeName ty) <> "'.") pure f
           _ -> avroTypeMismatch ty "object"
       A.Null -> case ty of
-                  Null -> return $ Ty.Null
+                  Null -> return Ty.Null
                   Union us _ | Null `elem` NE.toList us -> return $ Ty.Union us Null Ty.Null
                   _ -> avroTypeMismatch ty "null"
 
@@ -437,9 +441,9 @@ instance ToJSON Order where
 instance FromJSON Order where
   parseJSON (A.String s) =
     case s of
-      "ascending"  -> return $ Ascending
-      "descending" -> return $ Descending
-      "ignore"     -> return $ Ignore
+      "ascending"  -> return Ascending
+      "descending" -> return Descending
+      "ignore"     -> return Ignore
       _            -> fail $ "Unknown string for order: " <> T.unpack s
   parseJSON j = typeMismatch "Order" j
 
@@ -454,6 +458,7 @@ instance FromJSON Order where
 --  * Default values for unions can be cast as the type indicated by the
 --  first structure.
 --  * Default values can be cast/de-serialize correctly.
+--  * Named types are resolvable
 validateSchema :: Schema -> Parser ()
 validateSchema _sch = return () -- XXX TODO
 
@@ -476,9 +481,59 @@ buildTypeEnvironment failure from =
                 qual   = maybe [] (\x -> P.map (mappend (TN x <> ".")) unqual) ns
             in zip (unqual ++ qual) (repeat ty)
     in case ty of
-        Record {..} -> mk name aliases namespace ++ concatMap go (P.map fldType fields)
+        Record {..} -> mk name aliases namespace ++ concatMap (go . fldType) fields
         Enum {..}   -> mk name aliases namespace
         Union {..}  -> concatMap go options
         Fixed {..}  -> mk name aliases namespace
         Array {..}  -> go item
         _           -> []
+
+-- | Extracts all the records from the schema (flattens the schema)
+-- Named types get resolved when needed to include at least one "inlined"
+-- schema in each record and to make each record self-contained.
+-- Note: Namespaces are not really supported in this version. All the
+-- namespaces (including inlined into full names) will be ignored
+-- during names resolution.
+extractRecords :: Schema -> [Schema]
+extractRecords s = flip evalState S.empty . normSchema rawRecs <$> rawRecs
+  where
+    rawRecs = getRecs s
+    getRecs rec = case rec of
+      r@(Record _ _ _ _ _ fs) -> r : (fs >>= (getRecs . fldType))
+      Array t                 -> getRecs t
+      Union (t1 :| ts) _      -> getRecs t1 <> concatMap getRecs ts
+      Map t                   -> getRecs t
+      _                       -> []
+
+-- TODO: Currently ensures normalisation: only in one way
+-- that is needed for "extractRecord".
+-- it ensures that an "extracted" record is self-contained and
+-- all the named types are resolvable within the scope of the schema.
+-- The other way around (to each record is inlined only once and is referenced
+-- as a named type after that) is not implemented.
+normSchema :: [Schema] -- ^ List of all possible records
+           -> Schema   -- ^ Schema to normalise
+           -> State (S.Set TypeName) Schema
+normSchema rs r = case r of
+  t@(NamedType tn) -> do
+    let sn = shortName tn
+    resolved <- get
+    if S.member sn resolved
+      then pure t
+      else do
+        modify' (S.insert sn)
+        pure $ fromMaybe (error $ "Unable to resolve schema: " <> show (typeName t)) (findSchema tn)
+
+  Array s   -> Array <$> normSchema rs s
+  Map s     -> Map <$> normSchema rs s
+  Record{name = tn}  -> do
+    let sn = shortName tn
+    modify' (S.insert sn)
+    flds <- mapM (\fld -> setType fld <$> normSchema rs (fldType fld)) (fields r)
+    pure $ r { fields = flds }
+  s         -> pure s
+  where
+    shortName tn = TN $ T.takeWhileEnd (/='.') (unTN tn)
+    setType fld t = fld { fldType = t}
+    fullName s = TN $ maybe (typeName s) (\n -> typeName s <> "." <> n) (namespace s)
+    findSchema tn = L.find (\s -> name s == tn || fullName s == tn) rs

--- a/src/Data/Avro/TH.hs
+++ b/src/Data/Avro/TH.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Data.Avro.TH
+( deriveAvro
+, deriveFromAvro
+)
+where
+
+import           Control.Monad              (join)
+import           Data.Aeson                 (decode, eitherDecode)
+import qualified Data.Aeson                 as J
+import           Data.Avro                  hiding (decode, encode)
+import qualified Data.Avro                  as A
+import           Data.Avro.Schema           as S
+import qualified Data.Avro.Types            as AT
+import           Data.ByteString            (ByteString)
+import           Data.Int
+import           Data.List.NonEmpty
+import           Data.Map                   (Map)
+import           Data.Maybe                 (fromMaybe)
+import           Data.Semigroup             ((<>))
+import           Language.Haskell.TH        as TH
+import           Language.Haskell.TH.Syntax
+
+import qualified Data.ByteString.Lazy       as LBS
+import qualified Data.ByteString.Lazy.Char8 as LBSC8
+import           Data.Text                  (Text)
+import qualified Data.Text                  as T
+
+-- | Derives Avro from a given schema file.
+-- Generates data types, FromAvro and ToAvro instances.
+deriveAvro :: FilePath -> Q [Dec]
+deriveAvro p = do
+  qAddDependentFile p
+  mbSchema <- runIO $ decodeSchema p
+  case mbSchema of
+    Left err     -> fail $ "Unable to generate AVRO for " <> p <> ": " <> err
+    Right schema -> do
+      let recs = getAllRecords schema
+      types <- traverse genType recs
+      fromAvros <- traverse genFromAvro recs
+      toAvros <- traverse genToAvro recs
+      return $ join types <> join fromAvros <> join toAvros
+
+-- | Derives "read only" Avro from a given schema file.
+-- Generates data types and FromAvro.
+deriveFromAvro :: FilePath -> Q [Dec]
+deriveFromAvro p = do
+  qAddDependentFile p
+  mbSchema <- runIO $ decodeSchema p
+  case mbSchema of
+    Left err     -> fail $ "Unable to generate AVRO for " <> p <> ": " <> err
+    Right schema -> do
+      let recs = getAllRecords schema
+      types <- traverse genType recs
+      fromAvros <- traverse genFromAvro recs
+      return $ join types <> join fromAvros
+
+genFromAvro :: Schema -> Q [Dec]
+genFromAvro (S.Record (TN name) _ _ _ _ fs) =
+  [d| instance FromAvro $(conT . mkTextName $ name) where
+        fromAvro (AT.Record _ r) = $(genFromAvroFieldsExp (mkTextName name) fs) r
+        fromAvro r               = $( [|\v -> badValue v $(mkTextLit name)|] ) r
+  |]
+genFromAvro _                             = return []
+
+genFromAvroFieldsExp :: Name -> [Field] -> Q Exp
+genFromAvroFieldsExp n (x:xs) =
+  [| \r ->
+    $(let extract fld = [| r .: T.pack $(mkTextLit (fldName fld))|]
+          ctor = [| $(conE n) <$> $(extract x) |]
+      in foldl (\exp fld -> [| $exp <*> $(extract fld) |]) ctor xs
+     )
+  |]
+
+genToAvro :: Schema -> Q [Dec]
+genToAvro s@(Record (TN name) _ _ _ _ fs) = do
+  let sname = mkTextName (mkSchemaValueName name)
+  sdef <- schemaDef sname
+  idef <- toAvroInstance sname
+  pure (sdef <> idef)
+  where
+    schemaDef sname =
+      [d|
+          $(varP sname) = fromMaybe undefined (J.decode (LBSC8.pack $(mkLit (LBSC8.unpack $ J.encode s)))) :: Schema
+      |]
+    toAvroInstance sname =
+      [d| instance ToAvro $(conT . mkTextName $ name) where
+            toAvro = $(genToAvroFieldsExp name sname fs)
+            schema = pure $(varE sname)
+      |]
+    genToAvroFieldsExp prefix sname fs = [| \r -> record $(varE sname)
+        $(let assign fld = [| T.pack $(mkTextLit (fldName fld)) .= $(varE . mkTextName $ mkFieldTextName prefix fld) r |]
+          in listE $ assign <$> fs
+        )
+      |]
+
+getAllRecords :: Schema -> [Schema]
+getAllRecords r@(S.Record _ _ _ _ _ fs) = r : (fs >>= (getAllRecords . fldType))
+getAllRecords (S.Array t)               = getAllRecords t
+getAllRecords (S.Union (t1 :| [t2]) _)  = getAllRecords t1 <> getAllRecords t2
+getAllRecords (S.Map t)                 = getAllRecords t
+getAllRecords (S.Union (_ :| _:_:_) _)  = error "Unions with more than 2 elements are not yet supported"
+getAllRecords _                       = []
+
+genType :: Schema -> Q [Dec]
+genType (S.Record (TN name) _ _ _ _ fs) = do
+  fields <- traverse (mkField name) fs
+  let dname = mkTextName $ mkDataTypeName name
+  return [DataD [] dname [] Nothing [RecC dname fields] []]
+genType _ = return []
+
+mkSchemaValueName :: Text -> Text
+mkSchemaValueName r = "schema'" <> r
+
+mkDataTypeName :: Text -> Text
+mkDataTypeName =
+  updateFirst T.toUpper . T.takeWhileEnd (/='.')
+
+mkFieldTextName :: Text -> Field -> Text
+mkFieldTextName dn fld =
+  updateFirst T.toLower dn <> updateFirst T.toUpper (fldName fld)
+
+mkField :: Text -> Field -> Q VarBangType
+mkField prefix field = do
+  ftype <- mkFieldTypeName (fldType field)
+  let fName = mkName $ T.unpack (mkFieldTextName prefix field)
+  return (fName, defaultBang, ftype)
+
+mkFieldTypeName :: S.Type -> Q TH.Type
+mkFieldTypeName t = case t of
+  S.Boolean                     -> [t| Bool |]
+  S.Long                        -> [t| Int64 |]
+  S.Int                         -> [t| Int |]
+  S.Float                       -> [t| Float |]
+  S.Double                      -> [t| Double |]
+  S.Bytes                       -> [t| ByteString |]
+  S.String                      -> [t| Text |]
+  S.Union (Null :| [x]) _       -> [t| Maybe $(mkFieldTypeName x) |] -- AppT (ConT $ mkName "Maybe") (mkFieldTypeName x)
+  S.Union (x :| [Null]) _       -> [t| Maybe $(mkFieldTypeName x) |] --AppT (ConT $ mkName "Maybe") (mkFieldTypeName x)
+  S.Union (x :| [y]) _          -> [t| Either $(mkFieldTypeName x) $(mkFieldTypeName y) |] -- AppT (AppT (ConT (mkName "Either")) (mkFieldTypeName x)) (mkFieldTypeName y)
+  S.Record (TN x) _ _ _ _ _     -> [t| $(conT . mkTextName . mkDataTypeName $ x) |]
+  S.Map x                       -> [t| Map Text $(mkFieldTypeName x) |] --AppT (AppT (ConT (mkName "Map")) (ConT $ mkName "Text")) (mkFieldTypeName x)
+  S.Array x                     -> [t| [$(mkFieldTypeName x)] |]--AppT (ConT $ Text "[]") (mkFieldTypeName x)
+  S.NamedType (TN x)            -> [t| $(conT $ mkTextName (mkDataTypeName x))|] --ConT . mkName . T.unpack . mkDataTypeName $ x
+  S.Fixed (TN x) _ _ _          -> [t| $(conT $ mkTextName (mkDataTypeName x))|] --ConT . mkName . T.unpack . mkDataTypeName $ x
+  _                             -> error $ "Avro type is not supported: " <> show t
+
+updateFirst :: (Text -> Text) -> Text -> Text
+updateFirst f t =
+  let (l, ls) = T.splitAt 1 t
+  in f l <> ls
+
+decodeSchema :: FilePath -> IO (Either String Schema)
+decodeSchema p = eitherDecode <$> LBS.readFile p
+
+defaultBang = Bang NoSourceUnpackedness NoSourceStrictness
+
+mkTextName :: Text -> Name
+mkTextName = mkName . T.unpack
+
+mkLit = litE . StringL
+mkTextLit = litE . StringL . T.unpack

--- a/stack-6.yaml
+++ b/stack-6.yaml
@@ -1,0 +1,35 @@
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-6.35
+
+# Local packages, usually specified by relative directory name.
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: [pure-zlib-0.6]
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor

--- a/test/Avro/SchemaSpec.hs
+++ b/test/Avro/SchemaSpec.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Avro.SchemaSpec
+where
+
+import Data.Avro
+import Data.Avro.Schema
+import Data.Maybe
+import Test.Hspec
+import qualified Data.Aeson as J
+import qualified Data.ByteString.Lazy as LBS
+
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+spec :: Spec
+spec = describe "Avro.SchemaSpec: ExtractRecords" $ do
+  it "should extract records and resolve names" $ do
+    schBS <- LBS.readFile "test/data/reused.avsc"
+    let mbSchema = J.decode schBS :: Maybe Schema
+    mbSchema `shouldSatisfy` isJust
+    case mbSchema of
+      Nothing -> fail "Unable to decode schema"
+      Just sch -> do
+        let [a, b, c] = extractRecords sch
+
+        a `shouldBe` sch
+        take 1 (fldType <$> fields a) `shouldBe` [b]
+
+        let [fstInc, sndInc] = fldType <$> fields c
+        fstInc `shouldSatisfy` isRecord
+        sndInc `shouldSatisfy` isNamedType
+        typeName fstInc `shouldBe` typeName sndInc
+
+
+
+isNamedType :: Schema -> Bool
+isNamedType s = case s of
+  NamedType _ -> True
+  _ -> False
+
+isRecord :: Schema -> Bool
+isRecord s = case s of
+  Record {} -> True
+  _ -> False

--- a/test/Avro/THReusedSpec.hs
+++ b/test/Avro/THReusedSpec.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+module Avro.THReusedSpec
+where
+
+import           Data.Avro
+import           Data.Avro.TH
+
+import Test.Hspec
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+deriveAvro "test/data/reused.avsc"
+
+spec :: Spec
+spec = describe "Avro.THReusedSpec: Schema with named types" $ do
+  it "should do roundtrip" $ do
+    let msg = ReusedWrapper
+              { reusedWrapperFull  = ReusedChild 42
+              , reusedWrapperInner = ContainerChild
+                                     { containerChildFstIncluded = ReusedChild 100
+                                     , containerChildSndIncluded = ReusedChild 200
+                                     }
+              }
+    fromAvro (toAvro msg) `shouldBe` pure msg

--- a/test/Avro/THSimpleSpec.hs
+++ b/test/Avro/THSimpleSpec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell, StandaloneDeriving     #-}
+{-# LANGUAGE TemplateHaskell     #-}
 module Avro.THSimpleSpec
 where
 

--- a/test/Avro/THSimpleSpec.hs
+++ b/test/Avro/THSimpleSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell, StandaloneDeriving     #-}
-module Avro.THSpec
+module Avro.THSimpleSpec
 where
 
 import           Data.Avro

--- a/test/Avro/THSpec.hs
+++ b/test/Avro/THSpec.hs
@@ -13,16 +13,12 @@ import Test.Hspec
 
 deriveAvro "test/data/small.avsc"
 
-deriving instance Eq PortRange
-deriving instance Show PortRange
-deriving instance Eq Endpoint
-deriving instance Show Endpoint
-
 spec :: Spec
 spec = describe "Avro.THSpec: Small Schema" $ do
-  it "shold do roundtrip" $ do
+  it "should do roundtrip" $ do
     let msg = Endpoint
               { endpointIps   = ["192.168.1.1", "127.0.0.1"]
               , endpointPorts = [PortRange 1 10, PortRange 11 20]
               }
     fromAvro (toAvro msg) `shouldBe` pure msg
+

--- a/test/Avro/THSpec.hs
+++ b/test/Avro/THSpec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell, StandaloneDeriving     #-}
+module Avro.THSpec
+where
+
+import           Data.Avro
+import           Data.Avro.TH
+
+import Test.Hspec
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+deriveAvro "test/data/small.avsc"
+
+deriving instance Eq PortRange
+deriving instance Show PortRange
+deriving instance Eq Endpoint
+deriving instance Show Endpoint
+
+spec :: Spec
+spec = describe "Avro.THSpec: Small Schema" $ do
+  it "shold do roundtrip" $ do
+    let msg = Endpoint
+              { endpointIps   = ["192.168.1.1", "127.0.0.1"]
+              , endpointPorts = [PortRange 1 10, PortRange 11 20]
+              }
+    fromAvro (toAvro msg) `shouldBe` pure msg

--- a/test/data/reused.avsc
+++ b/test/data/reused.avsc
@@ -1,0 +1,37 @@
+{
+  "type": "record",
+  "name": "ReusedWrapper",
+  "namespace": "Boo",
+  "fields": [
+    {
+      "name": "full",
+      "type": {
+        "type": "record",
+        "name": "ReusedChild",
+        "fields": [
+          {
+            "name": "data",
+            "type": "int"
+          }
+        ]
+      }
+    },
+    {
+      "name": "inner",
+      "type": {
+        "type": "record",
+        "name": "ContainerChild",
+        "fields": [
+          {
+            "name": "fstIncluded",
+            "type": "ReusedChild"
+          },
+          {
+            "name": "sndIncluded",
+            "type": "ReusedChild"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/data/small.avsc
+++ b/test/data/small.avsc
@@ -1,0 +1,33 @@
+{
+  "type": "record",
+  "name": "Endpoint",
+  "fields": [
+    {
+      "name": "ips",
+      "type": {
+        "type": "array",
+        "items": "string"
+      }
+    },
+    {
+      "name": "ports",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "PortRange",
+          "fields": [
+            {
+              "name": "start",
+              "type": "int"
+            },
+            {
+              "name": "end",
+              "type": "int"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Changes

An initial attempt to generate `Avro` stuff:

This will generate data types, `FromAvro` and `ToAvro` instances:
```
deriveAvro "src/data/schema.avsc"
```

This will generate "read only Avro": only data types and `FromAvro` instances:
```
deriveFromAvro "src/data/schema.avsc"
```

There is room to improve, like:
- sanitising type/field names
- normalising `Schema`
- unit tests (!)
- general cleanup

But the TH part is there and it works!
