### PR TITLE
Rename to Deriving

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -30,11 +30,11 @@ library
                         Data.Avro.Decode,
                         Data.Avro.DecodeRaw,
                         Data.Avro.Deconflict,
+                        Data.Avro.Deriving,
                         Data.Avro.Encode,
                         Data.Avro.EncodeRaw,
                         Data.Avro.Schema,
                         Data.Avro.Types,
-                        Data.Avro.TH,
                         Data.Avro.Zag,
                         Data.Avro.Zig
   -- other-modules:

--- a/src/Data/Avro/Deriving.hs
+++ b/src/Data/Avro/Deriving.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
-module Data.Avro.TH
+module Data.Avro.Deriving
 ( deriveAvro
 , deriveFromAvro
 )
@@ -176,7 +176,7 @@ genDataType dn flds = do
 
 defaultStrictness :: Strict
 #if MIN_VERSION_template_haskell(2,11,0)
-defaultStrictness = Bang NoSourceUnpackedness NoSourceStrictness
+defaultStrictness = Bang SourceUnpack SourceStrict
 #else
 defaultStrictness = NotStrict
 #endif

--- a/test/Avro/THReusedSpec.hs
+++ b/test/Avro/THReusedSpec.hs
@@ -5,7 +5,7 @@ module Avro.THReusedSpec
 where
 
 import           Data.Avro
-import           Data.Avro.TH
+import           Data.Avro.Deriving
 
 import Test.Hspec
 

--- a/test/Avro/THSimpleSpec.hs
+++ b/test/Avro/THSimpleSpec.hs
@@ -5,7 +5,7 @@ module Avro.THSimpleSpec
 where
 
 import           Data.Avro
-import           Data.Avro.TH
+import           Data.Avro.Deriving
 
 import Test.Hspec
 


### PR DESCRIPTION
## Changes

- Rename `Data.Avro.TH` to `Data.Avro.Deriving`
- Added strictness/unpackedness